### PR TITLE
use new name of go-fqdn dependency repo

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ShowMax/go-fqdn"
+	"github.com/Showmax/go-fqdn"
 )
 
 // Encoder represents a component that encapsulates a target environment for


### PR DESCRIPTION
This dependency decided to change its GitHub name to a different upper/lowercase combination, which invalidated the currently used import path. Updating this to reflect the new path.